### PR TITLE
docs(readme): fix scorecard badge + drop premature downloads badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,10 @@
 # react-native-nitro-vision-kit
 
 [![npm version](https://img.shields.io/npm/v/react-native-nitro-vision-kit?logo=npm&label=npm)](https://www.npmjs.com/package/react-native-nitro-vision-kit)
-[![npm downloads](https://img.shields.io/npm/dm/react-native-nitro-vision-kit?logo=npm)](https://www.npmjs.com/package/react-native-nitro-vision-kit)
 [![CI](https://github.com/sagawrr/react-native-nitro-vision-kit/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/sagawrr/react-native-nitro-vision-kit/actions/workflows/ci.yml)
 [![Release](https://github.com/sagawrr/react-native-nitro-vision-kit/actions/workflows/release.yml/badge.svg)](https://github.com/sagawrr/react-native-nitro-vision-kit/actions/workflows/release.yml)
 [![License: MIT](https://img.shields.io/npm/l/react-native-nitro-vision-kit?color=blue)](https://github.com/sagawrr/react-native-nitro-vision-kit/blob/main/LICENSE)
-[![OpenSSF Scorecard](https://img.shields.io/ossf-scorecard/github.com/sagawrr/react-native-nitro-vision-kit?label=Scorecard&logo=openssf)](https://scorecard.dev/viewer/?uri=github.com/sagawrr/react-native-nitro-vision-kit)
+[![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/sagawrr/react-native-nitro-vision-kit/badge)](https://scorecard.dev/viewer/?uri=github.com/sagawrr/react-native-nitro-vision-kit)
 ![platforms](https://img.shields.io/badge/platforms-iOS%20%7C%20Android-blueviolet)
 ![supply chain](https://img.shields.io/badge/supply--chain-Socket%20%2B%20OIDC%20%2B%20provenance-success?logo=socket)
 


### PR DESCRIPTION
Two badge fixes from visual check:

- **Scorecard**: shields `ossf-scorecard` says 'invalid repo path' and repo isn't scored yet anyway (weekly workflow, hours-old repo). Switched to the canonical `api.scorecard.dev/.../badge` SVG, which renders cleanly now and shows a real score once the weekly run scores the repo.
- **npm downloads**: 'package not found or too new' — shields hasn't cached stats for a brand-new package. Dropped; re-add in a week once stats exist.

Kept (all rendering real values): npm version, CI, Release, License, platforms, supply-chain.