### PR TITLE
build(deps): setup-node v4 → v6.4.0 (with no-cache guard)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,13 +37,16 @@ jobs:
 
       - name: Setup Node (npm CLI w/ OIDC + registry auth)
         # node 22.14+ ships npm 11.5.1+, required for Trusted Publishing.
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: '22.14'
           registry-url: 'https://registry.npmjs.org'
-          # No `cache:` input is set on purpose: npm's guidance is to never
-          # cache in release builds (cache-poisoning / stale-tarball risk).
-          # setup-node@v4 only caches when `cache:` is provided.
+          # Explicitly disabled: npm's guidance is to never cache in release
+          # builds (cache-poisoning / stale-tarball risk). setup-node v5+ enables
+          # caching by default, so this MUST be set to false to preserve the
+          # no-cache release posture. Without it, the publish path silently gains
+          # a package-manager cache that CI (tag-only workflow) cannot catch.
+          package-manager-cache: false
 
       - name: Install dependencies
         # Non-frozen on purpose — see ci.yml. The published package is source +


### PR DESCRIPTION
Supersedes the closed dependabot #7.

**Why #7 was closed:** setup-node v5+ enables automatic package-manager caching **by default**. Our `release.yml` deliberately runs uncached per npm's explicit guidance (*"never cache in release builds"* — cache-poisoning/stale-tarball risk). Merging the bare bump would have silently flipped caching ON in the npm-publish path, and CI wouldn't catch it (`release.yml` only runs on tags).

**This PR:** bumps to v6.4.0 `48b55a01` AND sets `package-manager-cache: false`, so the no-cache release posture is preserved while still getting the Node 24 runtime + bug fixes.

Verified: `package-manager-cache` is a real v6 input (default `true`), YAML parses, the publish step explicitly opts out.